### PR TITLE
Replace png encoder

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,11 +22,9 @@
   "dependencies": {
     "async": "^0.9.0",
     "node-png": "^0.4.3",
-    "png-js": "^0.1.1",
     "yargs": "^3.7.0"
   },
-  "contributors":
-	[
-	"Joe Dytrych <j@dytry.ch> http://j.dytry.ch/"
-	]
+  "contributors": [
+    "Joe Dytrych <j@dytry.ch> http://j.dytry.ch/"
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "async": "^0.9.0",
-    "png": "^3.0.3",
+    "node-png": "^0.4.3",
     "png-js": "^0.1.1",
     "yargs": "^3.7.0"
   },

--- a/tool/Bundle.js
+++ b/tool/Bundle.js
@@ -1,6 +1,5 @@
 var fs = require('fs'),
   path = require('path'),
-  PNG = require('png-js'),
   nodePng = require('node-png');
 
 function Bundle(key) {
@@ -25,13 +24,13 @@ Bundle.prototype.files = function() {
 // Load a png file and decode it
 Bundle.prototype.load = function(filename, cb) {
   var self = this;
-  fs.readFile(filename, function(err, data) {
-    if (err) return cb(err);
-    (new PNG(data)).decode(function(pixels) {
-      self.decode(stripAlpha(pixels));
+  fs.createReadStream(filename)
+    .pipe(new nodePng.PNG())
+    .on('parsed', function() {
+      self.decode(stripAlpha(this.data));
       cb();
-    });
-  });
+    })
+    .on('error', cb);
 };
 
 // Decode a pixel buffer


### PR DESCRIPTION
Replace `node-png` with a png encoder that supports the latest node.js.

This version has no external dependencies, but is slightly slower than the previous version. Hopefully this will resolve #6 
